### PR TITLE
Bad

### DIFF
--- a/aaa.go
+++ b/aaa.go
@@ -1,8 +1,0 @@
-package model_convert
-
-import (
-	_ "github.com/go-sql-driver/mysql"
-	_ "github.com/jinzhu/gorm"
-	_ "github.com/jinzhu/gorm/dialects/postgres"
-	_ "github.com/lib/pq"
-)

--- a/aaa.go
+++ b/aaa.go
@@ -1,0 +1,1 @@
+package model_convert

--- a/model_convert.go
+++ b/model_convert.go
@@ -9,6 +9,11 @@ import (
 	"github.com/fwhezfwhez/errorx"
 
 	"github.com/jinzhu/gorm"
+
+	_ "github.com/go-sql-driver/mysql"
+	_ "github.com/jinzhu/gorm"
+	_ "github.com/jinzhu/gorm/dialects/postgres"
+	_ "github.com/lib/pq"
 )
 
 const (


### PR DESCRIPTION
This pr shows golang module bug of pkg loaded by "_" and will never be merged

master branch works well.

bad branch works bad for :
```
model_convert.go:13:2: unknown import path "github.com/go-sql-driver/mysql": cannot find package
model_convert.go:11:2: unknown import path "github.com/jinzhu/gorm": cannot find package
model_convert.go:15:2: unknown import path "github.com/jinzhu/gorm/dialects/postgres": cannot find package
model_convert.go:16:2: unknown import path "github.com/lib/pq": cannot find package
```


To well reproduce this:

`go 1.12.17`
`GO111MODULE=on`
```go
git clone https://github.com/fwhezfwhez/model_convert.git

cd model_convert
go test -run ^TestGenerateWhere$
```

```
model_convert.go:13:2: unknown import path "github.com/go-sql-driver/mysql": cannot find package

model_convert.go:11:2: unknown import path "github.com/jinzhu/gorm": cannot find package
model_convert.go:15:2: unknown import path "github.com/jinzhu/gorm/dialects/postgres": cannot fi
nd package
model_convert.go:16:2: unknown import path "github.com/lib/pq": cannot find package

```